### PR TITLE
Reorder hook items with after property to be placed after new hook item

### DIFF
--- a/src/hooks/hook.ts
+++ b/src/hooks/hook.ts
@@ -51,7 +51,14 @@ export abstract class Hook<TArgs extends unknown[], TReturn, TResult> implements
         return;
       }
     }
+    const afterItems = [];
+    const findAfterItem = () => this.#items.findIndex(item => item.after?.includes(id));
+    for (let afterIdx = findAfterItem(); afterIdx >= 0; afterIdx = findAfterItem()) {
+      const removedAfterItem = this.#items.splice(afterIdx, 1);
+      afterItems.push(...removedAfterItem);
+    }
     this.#items.push(item);
+    this.#items.push(...afterItems);
   }
 
   addObjHook<TObj extends Omit<HookItem<TArgs, TReturn>, 'action'>>(


### PR DESCRIPTION
When a hook item is added to a hook, the previously added hook items should be re-ordered, so that existing items which have an `after` property that includes the `id` of the item to add are placed **after** the new item.

Example: 

1. The hook contains items:
	* `{ "id": "a" }`
	* `{ "id": "b", "after": ["new"] }`
	* `{ "id": "c" }`
2. Add a new hook item `{ "id": "new" }`

Currently, `new` is placed after `c`, but `b` remains in-place. This PR proposes to move `b` after `new`, since `b` has an `after` property that includes `new`.

In `httpyac`, I need this behaviour in my own plugin which uses the `parseMetaData` hook to add actions to be executed after the `httpClient` `execute`-hook is triggered. My plugin would specify `{ "after": "httpClient" }`, but during `parseMetaData`, the `httpClient` action has not yet been added to the `execute` hook. (I can work around this issue, but the behaviour proposed by this PR would simplify things greatly.)
